### PR TITLE
fix(typescript): use typescript `@deprecated` tag for `context.github…

### DIFF
--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -34,6 +34,7 @@ See https://probot.github.io/docs/github-api/#graphql-api`)
 
     return graphql(args[0], args[1])
   }
+  // tslint:disable-next-line:deprecation
   client.query = (...args: any[]): any => {
     // tslint:disable-next-line:no-console
     console.warn('github.query is deprecated. Use github.graphql instead')

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -73,7 +73,7 @@ export interface GitHubAPI extends Octokit {
   paginate: Paginate
   graphql: Graphql
   /**
-   * .query() is deprecated, use .gaphql() instead
+   * @deprecated `.query()` is deprecated, use `.graphql()` instead
    */
   query: Graphql
 }

--- a/test/github/graphql.test.ts
+++ b/test/github/graphql.test.ts
@@ -128,6 +128,7 @@ describe('github/graphql', () => {
         .post('/graphql', { query })
         .reply(200, { data })
 
+      // tslint:disable-next-line:deprecation
       expect(await github.query(query)).toEqual(data)
       expect(consoleWarnSpy).toHaveBeenCalled()
     })


### PR DESCRIPTION
….query` (#938)

This improves the discovery of the deprecated method as IDEs and linters will mark the method as deprecated if you use the correct tag.