### PR TITLE
feat: Implement probot-config on context.config (#619)

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -59,3 +59,51 @@ Apps _should_ allow all settings to be customized for each installation.
 ### Store configuration in the repository
 
 Any configuration _should_ be stored in the target repository. Unless the app is using files from an established convention, the configuration _should_ be stored in the `.github` directory. See the [API docs for `context.config`](https://probot.github.io/api/latest/classes/context.html#config).
+
+`context.config` supports sharing configs between repositories. If configuration for your app is not available in the target repository, it will be loaded from the `.github` directory of the target organization's `.github` repository.
+
+User's can also choose their own shared location. Use the `_extends` option in the configuration file to extend settings from another repository.
+
+For example, given `.github/test.yml`:
+
+```yaml
+_extends: github-settings
+# Override values from the extended config or define new values
+name: myrepo
+```
+
+This configuration will be merged with the `.github/test.yml` file from the `github-settings` repository, which might look like this:
+
+```yaml
+shared1: will be merged
+shared2: will also be merged
+```
+
+Just put common configuration keys in a repository within your organization. Then reference this repository from config files with the same name.
+
+You can also reference configurations from other organizations:
+
+```yaml
+_extends: other/probot-settings
+other: DDD
+```
+
+Additionally, you can specify a specific path for the configuration by
+appending a colon after the project.
+
+```yaml
+_extends: probot-settings:.github/other_test.yaml
+other: FFF
+```
+
+Inherited configurations are in the **exact same location** within the
+repositories.
+
+```yaml
+# octocat/repo1:.github/test.yaml
+_extends: .github
+other: GGG
+
+# octocat/.github:test.yaml
+other: HHH
+```

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -6,43 +6,6 @@ next: docs/configuration.md
 
 While Probot doesn't have an official extension API (yet), there are a handful of reusable utilities that have been extracted from existing apps.
 
-## Config
-
-[probot-config](https://github.com/getsentry/probot-config) is an extension for sharing configs between repositories.
-
-
-```js
-const getConfig = require('probot-config')
-
-module.exports = app => {
-  app.on('push', async context => {
-    // Will look for 'test.yml' inside the '.github' folder
-    const config = await getConfig(context, 'test.yml')
-
-    context.log(config, 'Loaded config')
-  })
-}
-```
-
-Use the `_extends` option in your configuration file to extend settings from another repository.
-
-For example, given `.github/test.yml`:
-
-```yaml
-_extends: github-settings
-# Override values from the extended config or define new values
-name: myrepo
-```
-
-This configuration will be merged with the `.github/test.yml` file from the `github-settings` repository, which might look like this:
-
-```yaml
-shared1: will be merged
-shared2: will also be merged
-```
-
-Just put common configuration keys in a repository within your organization. Then reference this repository from config files with the same name.
-
 ## Commands
 
 [probot-commands](http://github.com/probot/commands) is an extension that adds slash commands to GitHub. Slash commands are lines that start with `/` in comments on Issues or Pull Requests that allow users to interact directly with your app.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -13,7 +13,7 @@ Probot includes a wrapper for the GitHub API which can enable you to store and m
 - *Comments:* The API can read, write and delete comments on issues and pull requests.
 - *Status:* The API can read and change the status of an issue or pull request.
 - *Search:* GitHub has a powerful search API that can be used
-- *Repository:* Built-in `context.config()` allows storing configuration in the repository.
+- *Repository:* Built-in `context.config()` allows storing configuration in the repository or the organization's `.github` repository.
 - *Labels:* The API can read labels, and add or remove them from issues and pull requests.
 
 If your Probot App needs to store more data than Issues and Pull Requests store normally, you can use the [`probot-metadata` extension](/docs/extensions#metadata) to hide data in comments. It isn't meant to be super secure or scalable, but it's an easy way to manage some data without a full database.

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "bunyan-sentry-stream": "^1.1.0",
     "cache-manager": "^2.4.0",
     "commander": "^2.19.0",
+    "deepmerge": "^3.2.0",
     "dotenv": "~8.0.0",
     "eventsource": "^1.0.7",
     "express": "^4.16.2",

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,8 +1,24 @@
+import { ReposGetContentsParams } from '@octokit/rest'
 import Webhooks, { PayloadRepository } from '@octokit/webhooks'
+import merge from 'deepmerge'
 import yaml from 'js-yaml'
 import path from 'path'
 import { GitHubAPI } from './github'
 import { LoggerWithTarget } from './wrap-logger'
+
+const CONFIG_PATH = '.github'
+const BASE_KEY = '_extends'
+const BASE_REGEX = new RegExp(
+  '^' +
+  '(?:([a-z\\d](?:[a-z\\d]|-(?=[a-z\\d])){0,38})/)?' + // org
+  '([-_.\\w\\d]+)' + // project
+  '(?::([-_./\\w\\d]+\\.ya?ml))?' + // filename
+    '$',
+  'i'
+)
+const DEFAULT_BASE = '.github'
+
+export type MergeOptions = merge.Options
 
 interface WebhookPayloadWithRepository {
   [key: string]: any
@@ -162,26 +178,86 @@ export class Context<E extends WebhookPayloadWithRepository = any> implements We
    * }
    * ```
    *
+   * Config files can also specify a base that they extend. `deepMergeOptions` can be used
+   * to configure how the target config, extended base, and default configs are merged.
+   *
    * @param fileName - Name of the YAML file in the `.github` directory
    * @param defaultConfig - An object of default config options
+   * @param deepMergeOptions - Controls merging configs (from the [deepmerge](https://github.com/TehShrike/deepmerge) module)
    * @return Configuration object read from the file
    */
-  public async config<T> (fileName: string, defaultConfig?: T) {
-    const params = this.repo({ path: path.posix.join('.github', fileName) })
+  public async config<T> (fileName: string, defaultConfig?: T, deepMergeOptions?: MergeOptions): Promise<object | null> {
+    const params = this.repo({ path: path.posix.join(CONFIG_PATH, fileName) })
+    const config = await this.loadYaml(params)
 
-    try {
-      const res = await this.github.repos.getContents(params)
-      const config = yaml.safeLoad(Buffer.from(res.data.content, 'base64').toString()) || {}
-      return Object.assign({}, defaultConfig, config)
-    } catch (err) {
-      if (err.status === 404) {
-        if (defaultConfig) {
-          return defaultConfig
-        }
-        return null
-      } else {
-        throw err
+    let baseRepo
+    if (config == null) {
+      baseRepo = DEFAULT_BASE
+    } else if (config != null && BASE_KEY in config) {
+      baseRepo = config[BASE_KEY]
+      delete config[BASE_KEY]
+    }
+
+    let baseConfig
+    if (baseRepo) {
+      if (typeof baseRepo !== 'string') {
+        throw new Error(`Invalid repository name in key "${BASE_KEY}"`)
       }
+
+      const baseParams = this.getBaseParams(params, baseRepo)
+      baseConfig = await this.loadYaml(baseParams)
+    }
+
+    if (config == null && baseConfig == null && !defaultConfig) {
+      return null
+    }
+
+    return merge.all(
+      // filter out null configs
+      [defaultConfig, baseConfig, config].filter(conf => conf),
+      deepMergeOptions
+    )
+  }
+
+  /**
+   * Loads a file from GitHub
+   *
+   * @param params Params to fetch the file with
+   * @return The parsed YAML file
+   */
+  private async loadYaml<T> (params: ReposGetContentsParams): Promise<any> {
+    try {
+      const response = await this.github.repos.getContents(params)
+      return yaml.safeLoad(Buffer.from(response.data.content, 'base64').toString()) || {}
+    } catch (e) {
+      if (e.status === 404) {
+        return null
+      }
+
+      throw e
+    }
+  }
+
+  /**
+   * Computes parameters for the repository specified in base
+   *
+   * Base can either be the name of a repository in the same organization or
+   * a full slug "organization/repo".
+   *
+   * @param params An object containing owner, repo and path
+   * @param base A string specifying the base repository
+   * @return The params of the base configuration
+   */
+  private getBaseParams (params: ReposGetContentsParams, base: string): ReposGetContentsParams {
+    const match = base.match(BASE_REGEX)
+    if (match === null) {
+      throw new Error(`Invalid repository name in key "${BASE_KEY}": ${base}`)
+    }
+
+    return {
+      owner: match[1] || params.owner,
+      path: match[3] || params.path,
+      repo: match[2]
     }
   }
 }

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -2,7 +2,7 @@ import fs = require('fs')
 import path = require('path')
 
 import Webhooks from '@octokit/webhooks'
-import { Context } from '../src/context'
+import { Context, MergeOptions } from '../src/context'
 import { GitHubAPI, OctokitError } from '../src/github'
 
 import { createMockResponse } from './fixtures/octokit/mock-response'
@@ -10,6 +10,11 @@ import { createMockResponse } from './fixtures/octokit/mock-response'
 describe('Context', () => {
   let event: Webhooks.WebhookEvent<any>
   let context: Context
+  const notFoundError: OctokitError = {
+    message: 'An error occurred',
+    name: 'OctokitError',
+    status: 404
+  }
 
   beforeEach(() => {
     event = {
@@ -93,10 +98,14 @@ describe('Context', () => {
   describe('config', () => {
     let github: GitHubAPI
 
-    function readConfig (fileName: string) {
+    function responseFromString (content: string) {
+      return createMockResponse({ content: Buffer.from(content).toString('base64') })
+    }
+
+    function responseFromConfig (fileName: string) {
       const configPath = path.join(__dirname, 'fixtures', 'config', fileName)
       const content = fs.readFileSync(configPath, { encoding: 'utf8' })
-      return { content: Buffer.from(content).toString('base64') }
+      return responseFromString(content)
     }
 
     beforeEach(() => {
@@ -105,9 +114,10 @@ describe('Context', () => {
     })
 
     it('gets a valid configuration', async () => {
-      jest.spyOn(github.repos, 'getContents').mockReturnValue(createMockResponse(readConfig('basic.yml')))
+      jest.spyOn(github.repos, 'getContents').mockReturnValue(responseFromConfig('basic.yml'))
       const config = await context.config('test-file.yml')
 
+      expect(github.repos.getContents).toHaveBeenCalledTimes(1)
       expect(github.repos.getContents).toHaveBeenCalledWith({
         owner: 'bkeepers',
         path: '.github/test-file.yml',
@@ -120,26 +130,24 @@ describe('Context', () => {
       })
     })
 
-    it('returns null when the file is missing', async () => {
-      const error: OctokitError = {
-        message: 'An error occurred',
-        name: 'OctokitError',
-        status: 404
-      }
-
-      jest.spyOn(github.repos, 'getContents').mockReturnValue(Promise.reject(error))
+    it('returns null when the file and base repository are missing', async () => {
+      jest.spyOn(github.repos, 'getContents').mockReturnValue(Promise.reject(notFoundError))
 
       expect(await context.config('test-file.yml')).toBe(null)
+      expect(github.repos.getContents).toHaveBeenCalledWith({
+        owner: 'bkeepers',
+        path: '.github/test-file.yml',
+        repo: 'probot'
+      })
+      expect(github.repos.getContents).toHaveBeenCalledWith({
+        owner: 'bkeepers',
+        path: '.github/test-file.yml',
+        repo: '.github'
+      })
     })
 
-    it('returns the default config when the file is missing and default config is passed', async () => {
-      const error: OctokitError = {
-        message: 'An error occurred',
-        name: 'OctokitError',
-        status: 404
-      }
-
-      jest.spyOn(github.repos, 'getContents').mockReturnValue(Promise.reject(error))
+    it('returns the default config when the file and base repository are missing and default config is passed', async () => {
+      jest.spyOn(github.repos, 'getContents').mockReturnValue(Promise.reject(notFoundError))
       const defaultConfig = {
         bar: 7,
         baz: 11,
@@ -149,8 +157,151 @@ describe('Context', () => {
       expect(contents).toEqual(defaultConfig)
     })
 
+    it('merges the default config', async () => {
+      jest.spyOn(github.repos, 'getContents').mockReturnValue(responseFromConfig('basic.yml'))
+
+      const config = await context.config('test-file.yml', { bar: 1, boa: 6 })
+
+      expect(github.repos.getContents).toHaveBeenCalledTimes(1)
+      expect(github.repos.getContents).toHaveBeenCalledWith({
+        owner: 'bkeepers',
+        path: '.github/test-file.yml',
+        repo: 'probot'
+      })
+      expect(config).toEqual({
+        bar: 7,
+        baz: 11,
+        boa: 6,
+        foo: 5
+      })
+    })
+
+    it('merges a base config', async () => {
+      jest.spyOn(github.repos, 'getContents')
+        .mockReturnValueOnce(responseFromString('boa: 6\nfoo: 0\n_extends: base'))
+        .mockReturnValueOnce(responseFromConfig('basic.yml'))
+
+      const config = await context.config('test-file.yml', { bar: 1, boa: 6 })
+
+      expect(github.repos.getContents).toHaveBeenCalledWith({
+        owner: 'bkeepers',
+        path: '.github/test-file.yml',
+        repo: 'probot'
+      })
+      expect(github.repos.getContents).toHaveBeenCalledWith({
+        owner: 'bkeepers',
+        path: '.github/test-file.yml',
+        repo: 'base'
+      })
+      expect(config).toEqual({
+        bar: 7,
+        baz: 11,
+        boa: 6,
+        foo: 0
+      })
+    })
+
+    it('merges the base and default config', async () => {
+      jest.spyOn(github.repos, 'getContents')
+        .mockReturnValueOnce(responseFromString('boa: 6\nfoo: 0\n_extends: base'))
+        .mockReturnValueOnce(responseFromConfig('basic.yml'))
+
+      const config = await context.config('test-file.yml', { bar: 1, new: true })
+
+      expect(github.repos.getContents).toHaveBeenCalledWith({
+        owner: 'bkeepers',
+        path: '.github/test-file.yml',
+        repo: 'probot'
+      })
+      expect(github.repos.getContents).toHaveBeenCalledWith({
+        owner: 'bkeepers',
+        path: '.github/test-file.yml',
+        repo: 'base'
+      })
+      expect(config).toEqual({
+        bar: 7,
+        baz: 11,
+        boa: 6,
+        foo: 0,
+        new: true
+      })
+    })
+
+    it('merges a base config from another organization', async () => {
+      jest.spyOn(github.repos, 'getContents')
+        .mockReturnValueOnce(responseFromString('boa: 6\nfoo: 0\n_extends: other/base'))
+        .mockReturnValueOnce(responseFromConfig('basic.yml'))
+
+      const config = await context.config('test-file.yml')
+
+      expect(github.repos.getContents).toHaveBeenCalledWith({
+        owner: 'bkeepers',
+        path: '.github/test-file.yml',
+        repo: 'probot'
+      })
+      expect(github.repos.getContents).toHaveBeenCalledWith({
+        owner: 'other',
+        path: '.github/test-file.yml',
+        repo: 'base'
+      })
+      expect(config).toEqual({
+        bar: 7,
+        baz: 11,
+        boa: 6,
+        foo: 0
+      })
+    })
+
+    it('merges a base config with a custom path', async () => {
+      jest.spyOn(github.repos, 'getContents')
+        .mockReturnValueOnce(responseFromString('boa: 6\nfoo: 0\n_extends: base:test.yml'))
+        .mockReturnValueOnce(responseFromConfig('basic.yml'))
+
+      const config = await context.config('test-file.yml')
+
+      expect(github.repos.getContents).toHaveBeenCalledWith({
+        owner: 'bkeepers',
+        path: '.github/test-file.yml',
+        repo: 'probot'
+      })
+      expect(github.repos.getContents).toHaveBeenCalledWith({
+        owner: 'bkeepers',
+        path: 'test.yml',
+        repo: 'base'
+      })
+      expect(config).toEqual({
+        bar: 7,
+        baz: 11,
+        boa: 6,
+        foo: 0
+      })
+    })
+
+    it('ignores a missing base config', async () => {
+      jest.spyOn(github.repos, 'getContents')
+        .mockReturnValueOnce(responseFromString('boa: 6\nfoo: 0\n_extends: base'))
+        .mockReturnValueOnce(Promise.reject(notFoundError))
+
+      const config = await context.config('test-file.yml')
+
+      expect(github.repos.getContents).toHaveBeenCalledWith({
+        owner: 'bkeepers',
+        path: '.github/test-file.yml',
+        repo: 'probot'
+      })
+      expect(github.repos.getContents).toHaveBeenCalledWith({
+        owner: 'bkeepers',
+        path: '.github/test-file.yml',
+        repo: 'base'
+      })
+      expect(config).toEqual({
+        boa: 6,
+        foo: 0
+      })
+    })
+
     it('throws when the configuration file is malformed', async () => {
-      jest.spyOn(github.repos, 'getContents').mockReturnValue(createMockResponse(readConfig('malformed.yml')))
+      jest.spyOn(github.repos, 'getContents').mockReturnValue(responseFromConfig('malformed.yml'))
 
       let e
       let contents
@@ -166,7 +317,7 @@ describe('Context', () => {
     })
 
     it('throws when loading unsafe yaml', async () => {
-      jest.spyOn(github.repos, 'getContents').mockReturnValue(createMockResponse(readConfig('evil.yml')))
+      jest.spyOn(github.repos, 'getContents').mockReturnValue(responseFromConfig('evil.yml'))
 
       let e
       let config
@@ -181,23 +332,54 @@ describe('Context', () => {
       expect(e.message).toMatch(/unknown tag/)
     })
 
+    it('throws on a non-string base', async () => {
+      jest.spyOn(github.repos, 'getContents')
+        .mockReturnValue(responseFromString('boa: 6\nfoo: 0\n_extends: { nope }'))
+
+      let e
+      let config
+      try {
+        config = await context.config('test-file.yml')
+      } catch (err) {
+        e = err
+      }
+
+      expect(config).toBeUndefined()
+      expect(e).toBeDefined()
+      expect(e.message).toMatch(/invalid/i)
+    })
+
+    it('throws on an invalid base', async () => {
+      jest.spyOn(github.repos, 'getContents')
+        .mockReturnValue(responseFromString('boa: 6\nfoo: 0\n_extends: "nope:"'))
+
+      let e
+      let config
+      try {
+        config = await context.config('test-file.yml')
+      } catch (err) {
+        e = err
+      }
+
+      expect(config).toBeUndefined()
+      expect(e).toBeDefined()
+      expect(e.message).toMatch(/nope:/)
+    })
+
     it('returns an empty object when the file is empty', async () => {
-      jest.spyOn(github.repos, 'getContents').mockReturnValue(createMockResponse(readConfig('empty.yml')))
+      jest.spyOn(github.repos, 'getContents').mockReturnValue(responseFromConfig('empty.yml'))
 
       const contents = await context.config('test-file.yml')
 
+      expect(github.repos.getContents).toHaveBeenCalledTimes(1)
       expect(contents).toEqual({})
     })
 
     it('overwrites default config settings', async () => {
-      jest.spyOn(github.repos, 'getContents').mockReturnValue(createMockResponse(readConfig('basic.yml')))
+      jest.spyOn(github.repos, 'getContents').mockReturnValue(responseFromConfig('basic.yml'))
       const config = await context.config('test-file.yml', { foo: 10 })
 
-      expect(github.repos.getContents).toHaveBeenCalledWith({
-        owner: 'bkeepers',
-        path: '.github/test-file.yml',
-        repo: 'probot'
-      })
+      expect(github.repos.getContents).toHaveBeenCalledTimes(1)
       expect(config).toEqual({
         bar: 7,
         baz: 11,
@@ -206,19 +388,87 @@ describe('Context', () => {
     })
 
     it('uses default settings to fill in missing options', async () => {
-      jest.spyOn(github.repos, 'getContents').mockReturnValue(createMockResponse(readConfig('missing.yml')))
+      jest.spyOn(github.repos, 'getContents').mockReturnValue(responseFromConfig('missing.yml'))
       const config = await context.config('test-file.yml', { bar: 7 })
+
+      expect(github.repos.getContents).toHaveBeenCalledTimes(1)
+      expect(config).toEqual({
+        bar: 7,
+        baz: 11,
+        foo: 5
+      })
+    })
+
+    it('uses the .github directory on a .github repo', async () => {
+      jest.spyOn(github.repos, 'getContents')
+        .mockReturnValueOnce(responseFromString('foo: foo\n_extends: .github'))
+        .mockReturnValueOnce(responseFromConfig('basic.yml'))
+      const config = await context.config('test-file.yml')
 
       expect(github.repos.getContents).toHaveBeenCalledWith({
         owner: 'bkeepers',
         path: '.github/test-file.yml',
         repo: 'probot'
       })
+      expect(github.repos.getContents).toHaveBeenCalledWith({
+        owner: 'bkeepers',
+        path: '.github/test-file.yml',
+        repo: '.github'
+      })
+      expect(config).toEqual({
+        bar: 7,
+        baz: 11,
+        foo: 'foo'
+      })
+    })
+
+    it('defaults to .github repo if no config found', async () => {
+      jest.spyOn(github.repos, 'getContents')
+        .mockReturnValueOnce(Promise.reject(notFoundError))
+        .mockReturnValueOnce(responseFromConfig('basic.yml'))
+      const config = await context.config('test-file.yml')
+
+      expect(github.repos.getContents).toHaveBeenCalledWith({
+        owner: 'bkeepers',
+        path: '.github/test-file.yml',
+        repo: 'probot'
+      })
+      expect(github.repos.getContents).toHaveBeenCalledWith({
+        owner: 'bkeepers',
+        path: '.github/test-file.yml',
+        repo: '.github'
+      })
       expect(config).toEqual({
         bar: 7,
         baz: 11,
         foo: 5
       })
+    })
+
+    it('deep merges the base config', async () => {
+      jest.spyOn(github.repos, 'getContents')
+        .mockReturnValueOnce(responseFromString('obj:\n  foo:\n  - name: master\n_extends: .github'))
+        .mockReturnValueOnce(responseFromString('obj:\n  foo:\n  - name: develop'))
+      const config = await context.config('test-file.yml')
+
+      expect(config).toEqual({
+        obj: {
+          foo: [
+            { name: 'develop' },
+            { name: 'master' }
+          ]
+        }
+      })
+    })
+
+    it('accepts deepmerge options', async () => {
+      jest.spyOn(github.repos, 'getContents')
+        .mockReturnValueOnce(responseFromString('foo:\n  - name: master\n    shouldChange: changed\n_extends: .github'))
+        .mockReturnValueOnce(responseFromString('foo:\n  - name: develop\n  - name: master\n    shouldChange: should'))
+
+      const customMerge = jest.fn((_target: any[], _source: any[], _options: MergeOptions | undefined): any[] => [])
+      await context.config('test-file.yml', {}, { arrayMerge: customMerge })
+      expect(customMerge).toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
Implements the functionality of https://github.com/probot/probot-config
in context.config. This adds the ability to have config fallback to a
`.github` project in the target repository's organization, or for
repository configs to specify a particular repository to merge config
from.